### PR TITLE
font style 클래스 설정

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -2,12 +2,14 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import MainPage from "./pages/main";
 import GlobalStyles from "./GlobalStyles";
 import "./fonts.css";
+import ListPage from "./pages/list";
 const AppRouter = () => {
   return (
     <BrowserRouter>
       <GlobalStyles />
       <Routes>
-        <Route path='/' element={<MainPage />} />
+        <Route path="/" element={<MainPage />} />
+        <Route path="/list" element={<ListPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/fonts.css
+++ b/src/fonts.css
@@ -11,3 +11,143 @@
   font-style: normal;
   font-weight: 700;
 }
+
+.font-28-bold {
+  /* Font/28 Bold */
+  font-family: Pretendard;
+  font-size: 2.8rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 4.2rem; /* 150% */
+  letter-spacing: -0.028rem;
+}
+
+.font-24-bold {
+  /* Font/24 Bold */
+  font-family: Pretendard;
+  font-size: 2.4rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 3.6rem; /* 150% */
+  letter-spacing: -0.024rem;
+}
+
+.font-24-regular {
+  /* Font/24 Regular */
+  font-family: Pretendard;
+  font-size: 2.4rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 3.6rem; /* 150% */
+  letter-spacing: -0.024rem;
+}
+
+.font-20-bold {
+  /* Font/20 Bold */
+  font-family: Pretendard;
+  font-size: 2rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 3rem; /* 150% */
+  letter-spacing: -0.02rem;
+}
+
+.font-20-regular {
+  /* Font/20 Regular */
+  font-family: Pretendard;
+  font-size: 2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 3rem; /* 150% */
+  letter-spacing: -0.02rem;
+}
+
+.font-18-bold {
+  /* Font/18 Bold */
+  font-family: Pretendard;
+  font-size: 1.8rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2.8rem; /* 155.556% */
+  letter-spacing: -0.018rem;
+}
+
+.font-18-regular {
+  /* Font/18 Regular */
+  font-family: Pretendard;
+  font-size: 1.8rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 2.8rem; /* 155.556% */
+  letter-spacing: -0.018rem;
+}
+
+.font-16-bold {
+  /* Font/16 Bold */
+  font-family: Pretendard;
+  font-size: 1.6rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2.6rem; /* 162.5% */
+  letter-spacing: -0.016rem;
+}
+
+.font-16-regular {
+  /* Font/16 Regular */
+  font-family: Pretendard;
+  font-size: 1.6rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 2.6rem; /* 162.5% */
+  letter-spacing: -0.016rem;
+}
+
+.font-15-regular {
+  /* Font/15 Regular */
+  font-family: Pretendard;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 2.2rem; /* 146.667% */
+  letter-spacing: -0.015rem;
+}
+
+.font-15-bold {
+  /* Font/15 Bold */
+  font-family: Pretendard;
+  font-size: 1.5rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2.2rem; /* 146.667% */
+  letter-spacing: -0.015rem;
+}
+
+.font-14-regular {
+  /* Font/14 Regular */
+  font-family: Pretendard;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 2rem; /* 142.857% */
+  letter-spacing: -0.007rem;
+}
+
+.font-14-bold {
+  /* Font/14 Bold */
+  font-family: Pretendard;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 2rem; /* 142.857% */
+  letter-spacing: -0.007rem;
+}
+
+.font-12-regular {
+  /* Font/12 Regular */
+  font-family: Pretendard;
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.8rem; /* 150% */
+  letter-spacing: -0.006rem;
+}

--- a/src/pages/list/components/Card/Card.jsx
+++ b/src/pages/list/components/Card/Card.jsx
@@ -1,0 +1,29 @@
+import * as S from "./Card.style";
+
+const Card = () => {
+  const userName = "John";
+  return (
+    <S.Container>
+      <S.InfoContainer>
+        <p className="font-24-bold">To. {userName}</p>
+        <p>icons</p>
+        <p className="font-16-regular">
+          <span className="font-16-bold">30</span>명이 작성했어요!
+        </p>
+      </S.InfoContainer>
+      <S.BadgeContainer>
+        <S.Badge>
+          <span className="number">👍 20</span>
+        </S.Badge>
+        <S.Badge>
+          <span className="number">👍 20</span>
+        </S.Badge>
+        <S.Badge>
+          <span className="number">👍 20</span>
+        </S.Badge>
+      </S.BadgeContainer>
+    </S.Container>
+  );
+};
+
+export default Card;

--- a/src/pages/list/components/Card/Card.style.js
+++ b/src/pages/list/components/Card/Card.style.js
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  width: 27.5rem;
+  height: 26rem;
+  padding: 2.4rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 4.3rem;
+
+  border-radius: 1.6rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--Purple-200, #ecd9ff);
+  box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
+`;
+
+export const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+`;
+
+export const BadgeContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.8rem;
+  border-top: 0.1rem solid rgba(0, 0, 0, 0.12);
+  padding-top: 1.6rem;
+`;
+
+export const Badge = styled.div`
+  display: flex;
+  padding: 0.8rem 1.2rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+
+  border-radius: 3.2rem;
+  background: rgba(0, 0, 0, 0.54);
+
+  .number {
+    color: #fff;
+    font-family: Pretendard;
+    font-size: 1.6rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 2rem; /* 125% */
+  }
+`;

--- a/src/pages/list/index.jsx
+++ b/src/pages/list/index.jsx
@@ -1,0 +1,12 @@
+import Card from "./components/Card/Card";
+
+const ListPage = () => {
+  return (
+    <div>
+      <p className="font-24-bold">인기 롤링 페이퍼 🔥</p>
+      <Card />
+    </div>
+  );
+};
+
+export default ListPage;


### PR DESCRIPTION
## 주요 변경 사항
fonts.css 파일에 폰트 스타일을 클래스로 미리 다 정의해둠

## 사용 방법
<img width="296" alt="image" src="https://github.com/innerstella/itsBasic/assets/77491430/814f2140-3abd-44f8-8b79-b1b37c68e524">

위 같은 경우 Font/24 Bold 이므로, 해당 폰트 스타일을 적용해야 할 태그에 `className = 'font-24-bold'`로 적용해서 사용하면 됨



----
※ 카드 리스트 컴포넌트는 아직 작업 중.. 
※ GitHub Actions에서 에러가 난 것 같은데 (배포 관련이라) 당장은 중요하지 않으니 나중에 고쳐보겠습니당