### PR TITLE
Emoji 관련 기능 완성 및 유효하지 않은 페이지 이동시 버그 수정#44 

### DIFF
--- a/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
+++ b/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
@@ -3,6 +3,7 @@ import EmojiPicker from "emoji-picker-react";
 import { useState } from "react";
 import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel";
 import { useParams } from "react-router";
+import { toastNotify } from "../../../../utils/callToastNotify";
 
 function HeaderAddEmojiButton({ emojiFunc }) {
 	const [isEmojiOpen, setIsEmojiOpen] = useState(false);
@@ -41,6 +42,11 @@ function HeaderAddEmojiButton({ emojiFunc }) {
 				);
 				localStorage.setItem(s.emoji, "decreased");
 			}
+			const notifyMessage =
+				localStorage.getItem(s.emoji) === "increased"
+					? "리액션이 성공적으로 추가되었습니다."
+					: "리액션이 성공적으로 제거되었습니다.";
+			toastNotify(notifyMessage);
 
 			emojiFunc(recipientId);
 		} finally {

--- a/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
+++ b/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
@@ -3,55 +3,11 @@ import EmojiPicker from "emoji-picker-react";
 import { useState } from "react";
 import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel";
 import { useParams } from "react-router";
-import { toastNotify } from "../../../../utils/callToastNotify";
+import handleEmojiSelect from "../Utils/handleEmojiSelect";
 
 function HeaderAddEmojiButton({ emojiFunc }) {
 	const [isEmojiOpen, setIsEmojiOpen] = useState(false);
 	const { recipientId } = useParams();
-
-	const handleEmojiSelect = async (s) => {
-		try {
-			if (localStorage.getItem(s.emoji) !== "increased") {
-				await fetch(
-					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
-					{
-						method: "POST",
-						headers: {
-							accept: "application/json",
-							"Content-Type": "application/json",
-							"X-CSRFToken":
-								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
-						},
-						body: JSON.stringify({ emoji: s.emoji, type: "increase" }),
-					}
-				);
-				localStorage.setItem(s.emoji, "increased");
-			} else {
-				await fetch(
-					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
-					{
-						method: "POST",
-						headers: {
-							accept: "application/json",
-							"Content-Type": "application/json",
-							"X-CSRFToken":
-								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
-						},
-						body: JSON.stringify({ emoji: s.emoji, type: "decrease" }),
-					}
-				);
-				localStorage.setItem(s.emoji, "decreased");
-			}
-			const notifyMessage =
-				localStorage.getItem(s.emoji) === "increased"
-					? "리액션이 성공적으로 추가되었습니다."
-					: "리액션이 성공적으로 제거되었습니다.";
-			toastNotify(notifyMessage);
-
-			emojiFunc(recipientId);
-		} finally {
-		}
-	};
 
 	return (
 		<S.EmojiToggleBtnContainer>
@@ -66,7 +22,9 @@ function HeaderAddEmojiButton({ emojiFunc }) {
 				{isEmojiOpen && (
 					<EmojiPicker
 						emojiStyle='twitter'
-						onEmojiClick={(select) => handleEmojiSelect(select)}
+						onEmojiClick={(sel) =>
+							handleEmojiSelect(sel.emoji, recipientId, emojiFunc)
+						}
 					/>
 				)}
 			</S.EmojiPickerPositioner>

--- a/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
+++ b/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel";
 import { useParams } from "react-router";
 
-function HeaderAddEmojiButton() {
+function HeaderAddEmojiButton({ emojiFunc }) {
 	const [isEmojiOpen, setIsEmojiOpen] = useState(false);
 	const { recipientId } = useParams();
 
@@ -23,6 +23,7 @@ function HeaderAddEmojiButton() {
 					body: JSON.stringify({ emoji: s.emoji, type: "increase" }),
 				}
 			);
+			emojiFunc(recipientId);
 		} finally {
 		}
 	};

--- a/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
+++ b/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
@@ -10,19 +10,38 @@ function HeaderAddEmojiButton({ emojiFunc }) {
 
 	const handleEmojiSelect = async (s) => {
 		try {
-			await fetch(
-				`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
-				{
-					method: "POST",
-					headers: {
-						accept: "application/json",
-						"Content-Type": "application/json",
-						"X-CSRFToken":
-							"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
-					},
-					body: JSON.stringify({ emoji: s.emoji, type: "increase" }),
-				}
-			);
+			if (localStorage.getItem(s.emoji) !== "increased") {
+				await fetch(
+					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
+					{
+						method: "POST",
+						headers: {
+							accept: "application/json",
+							"Content-Type": "application/json",
+							"X-CSRFToken":
+								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
+						},
+						body: JSON.stringify({ emoji: s.emoji, type: "increase" }),
+					}
+				);
+				localStorage.setItem(s.emoji, "increased");
+			} else {
+				await fetch(
+					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
+					{
+						method: "POST",
+						headers: {
+							accept: "application/json",
+							"Content-Type": "application/json",
+							"X-CSRFToken":
+								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
+						},
+						body: JSON.stringify({ emoji: s.emoji, type: "decrease" }),
+					}
+				);
+				localStorage.setItem(s.emoji, "decreased");
+			}
+
 			emojiFunc(recipientId);
 		} finally {
 		}

--- a/src/pages/post/components/HeaderButtonBox/HeaderButtonBox.jsx
+++ b/src/pages/post/components/HeaderButtonBox/HeaderButtonBox.jsx
@@ -1,13 +1,13 @@
 import HeaderAddEmojiButton from "../HeaderAddEmojiButton/HeaderAddEmojiButton";
 import HeaderShareButton from "../HeaderShareButton/HeaderShareButton";
 import * as S from "./HeaderButtonBox.style";
-const HeaderButtonBox = () => {
-  return (
-    <S.Box>
-      <HeaderAddEmojiButton />
-      <HeaderShareButton />
-    </S.Box>
-  );
+const HeaderButtonBox = ({ emojiFunc }) => {
+	return (
+		<S.Box>
+			<HeaderAddEmojiButton emojiFunc={emojiFunc} />
+			<HeaderShareButton />
+		</S.Box>
+	);
 };
 
 export default HeaderButtonBox;

--- a/src/pages/post/components/HeaderServiceBox/HeaderServiceBox.jsx
+++ b/src/pages/post/components/HeaderServiceBox/HeaderServiceBox.jsx
@@ -2,15 +2,38 @@ import * as S from "./HeaderServiceBox.style";
 import MessageWriterBox from "../MessageWriterBox/MessageWriterBox";
 import MostEmojiBox from "../MostEmojiBox/MostEmojiBox";
 import HeaderButtonBox from "../HeaderButtonBox/HeaderButtonBox";
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+
+const fetchEmojiData = async (recipientId) => {
+	const { results } = await (
+		await fetch(
+			`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`
+		)
+	).json();
+	return results;
+};
 
 const HeaderServiceBox = () => {
-  return (
-    <S.Container>
-      <MessageWriterBox />
-      <MostEmojiBox />
-      <HeaderButtonBox />
-    </S.Container>
-  );
+	const [emojiData, setEmojiData] = useState([]);
+	const { recipientId } = useParams();
+
+	const handleSetEmojiData = async (recipientId) => {
+		const emojiRaw = await fetchEmojiData(recipientId);
+		setEmojiData(emojiRaw);
+	};
+
+	useEffect(() => {
+		handleSetEmojiData(recipientId);
+	}, [recipientId]);
+
+	return (
+		<S.Container>
+			<MessageWriterBox />
+			<MostEmojiBox emojiData={emojiData} />
+			<HeaderButtonBox emojiFunc={handleSetEmojiData} />
+		</S.Container>
+	);
 };
 
 export default HeaderServiceBox;

--- a/src/pages/post/components/HeaderServiceBox/HeaderServiceBox.jsx
+++ b/src/pages/post/components/HeaderServiceBox/HeaderServiceBox.jsx
@@ -19,8 +19,14 @@ const HeaderServiceBox = () => {
 	const { recipientId } = useParams();
 
 	const handleSetEmojiData = async (recipientId) => {
-		const emojiRaw = await fetchEmojiData(recipientId);
-		setEmojiData(emojiRaw);
+		setEmojiData([]);
+		try {
+			const emojiRaw = await fetchEmojiData(recipientId);
+			if (!emojiRaw) {
+				throw new Error("정상적인 페이지 접근이 아닙니다.");
+			}
+			setEmojiData(emojiRaw);
+		} catch {}
 	};
 
 	useEffect(() => {

--- a/src/pages/post/components/HeaderServiceBox/HeaderServiceBox.jsx
+++ b/src/pages/post/components/HeaderServiceBox/HeaderServiceBox.jsx
@@ -36,7 +36,7 @@ const HeaderServiceBox = () => {
 	return (
 		<S.Container>
 			<MessageWriterBox />
-			<MostEmojiBox emojiData={emojiData} />
+			<MostEmojiBox emojiData={emojiData} emojiFunc={handleSetEmojiData} />
 			<HeaderButtonBox emojiFunc={handleSetEmojiData} />
 		</S.Container>
 	);

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
@@ -1,8 +1,50 @@
 import { useEffect, useState } from "react";
 import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel.jsx";
 import * as S from "./MostEmojiBox.style.jsx";
+import { useParams } from "react-router";
 
-const EmojiDropDown = (emojiList) => {
+const EmojiDropDown = ({ emojiList, emojiFunc }) => {
+	const { recipientId } = useParams();
+
+	const handleEmojiSelect = async (emoji) => {
+		try {
+			if (localStorage.getItem(emoji) !== "increased") {
+				await fetch(
+					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
+					{
+						method: "POST",
+						headers: {
+							accept: "application/json",
+							"Content-Type": "application/json",
+							"X-CSRFToken":
+								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
+						},
+						body: JSON.stringify({ emoji: emoji, type: "increase" }),
+					}
+				);
+				localStorage.setItem(emoji, "increased");
+			} else {
+				await fetch(
+					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
+					{
+						method: "POST",
+						headers: {
+							accept: "application/json",
+							"Content-Type": "application/json",
+							"X-CSRFToken":
+								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
+						},
+						body: JSON.stringify({ emoji: emoji, type: "decrease" }),
+					}
+				);
+				localStorage.setItem(emoji, "decreased");
+			}
+
+			emojiFunc(recipientId);
+		} finally {
+		}
+	};
+
 	return (
 		<>
 			{emojiList.length === 0 ? (
@@ -14,7 +56,11 @@ const EmojiDropDown = (emojiList) => {
 			) : (
 				<S.EmojiListContainer>
 					{emojiList.map((item) => (
-						<S.EmojiUsedWrapper key={item.emoji} className='font-16-regular'>
+						<S.EmojiUsedWrapper
+							key={item.emoji}
+							className='font-16-regular'
+							onClick={() => handleEmojiSelect(item.emoji)}
+						>
 							<span>{item.emoji}</span>
 							{item.count}
 						</S.EmojiUsedWrapper>
@@ -25,7 +71,7 @@ const EmojiDropDown = (emojiList) => {
 	);
 };
 
-const MostEmojiBox = ({ emojiData }) => {
+const MostEmojiBox = ({ emojiData, emojiFunc }) => {
 	const [isEmojiDropDownOpen, setIsEmojiDropDownOpen] = useState(false);
 	const [favoriteEmoji, setFavoriteEmoji] = useState([]);
 	const [usedEmojiList, setUsedEmojiList] = useState([]);
@@ -64,7 +110,9 @@ const MostEmojiBox = ({ emojiData }) => {
 				>
 					<img src='/assets/emoji_picker_dropdown_icon.svg' alt='' />
 				</S.DropdownButton>
-				{isEmojiDropDownOpen && EmojiDropDown(usedEmojiList)}
+				{isEmojiDropDownOpen && (
+					<EmojiDropDown emojiList={usedEmojiList} emojiFunc={emojiFunc} />
+				)}
 				<DropdownClickCancel
 					isOpen={isEmojiDropDownOpen}
 					setIsOpen={setIsEmojiDropDownOpen}

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel.jsx";
 import * as S from "./MostEmojiBox.style.jsx";
 import { useParams } from "react-router";
+import { toastNotify } from "../../../../utils/callToastNotify.js";
 
 const EmojiDropDown = ({ emojiList, emojiFunc }) => {
 	const { recipientId } = useParams();
@@ -39,7 +40,11 @@ const EmojiDropDown = ({ emojiList, emojiFunc }) => {
 				);
 				localStorage.setItem(emoji, "decreased");
 			}
-
+			const notifyMessage =
+				localStorage.getItem(emoji) === "increased"
+					? "리액션이 성공적으로 추가되었습니다."
+					: "리액션이 성공적으로 제거되었습니다.";
+			toastNotify(notifyMessage);
 			emojiFunc(recipientId);
 		} finally {
 		}

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
@@ -2,54 +2,9 @@ import { useEffect, useState } from "react";
 import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel.jsx";
 import * as S from "./MostEmojiBox.style.jsx";
 import { useParams } from "react-router";
-import { toastNotify } from "../../../../utils/callToastNotify.js";
+import handleEmojiSelect from "../Utils/handleEmojiSelect.js";
 
-const EmojiDropDown = ({ emojiList, emojiFunc }) => {
-	const { recipientId } = useParams();
-
-	const handleEmojiSelect = async (emoji) => {
-		try {
-			if (localStorage.getItem(emoji) !== "increased") {
-				await fetch(
-					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
-					{
-						method: "POST",
-						headers: {
-							accept: "application/json",
-							"Content-Type": "application/json",
-							"X-CSRFToken":
-								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
-						},
-						body: JSON.stringify({ emoji: emoji, type: "increase" }),
-					}
-				);
-				localStorage.setItem(emoji, "increased");
-			} else {
-				await fetch(
-					`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
-					{
-						method: "POST",
-						headers: {
-							accept: "application/json",
-							"Content-Type": "application/json",
-							"X-CSRFToken":
-								"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
-						},
-						body: JSON.stringify({ emoji: emoji, type: "decrease" }),
-					}
-				);
-				localStorage.setItem(emoji, "decreased");
-			}
-			const notifyMessage =
-				localStorage.getItem(emoji) === "increased"
-					? "리액션이 성공적으로 추가되었습니다."
-					: "리액션이 성공적으로 제거되었습니다.";
-			toastNotify(notifyMessage);
-			emojiFunc(recipientId);
-		} finally {
-		}
-	};
-
+const EmojiDropDown = ({ emojiList, emojiFunc, recipientId }) => {
 	return (
 		<>
 			{emojiList.length === 0 ? (
@@ -64,7 +19,9 @@ const EmojiDropDown = ({ emojiList, emojiFunc }) => {
 						<S.EmojiUsedWrapper
 							key={item.emoji}
 							className='font-16-regular'
-							onClick={() => handleEmojiSelect(item.emoji)}
+							onClick={() =>
+								handleEmojiSelect(item.emoji, recipientId, emojiFunc)
+							}
 						>
 							<span>{item.emoji}</span>
 							{item.count}
@@ -80,6 +37,7 @@ const MostEmojiBox = ({ emojiData, emojiFunc }) => {
 	const [isEmojiDropDownOpen, setIsEmojiDropDownOpen] = useState(false);
 	const [favoriteEmoji, setFavoriteEmoji] = useState([]);
 	const [usedEmojiList, setUsedEmojiList] = useState([]);
+	const { recipientId } = useParams();
 
 	useEffect(() => {
 		if (emojiData.length !== 0) {
@@ -116,7 +74,11 @@ const MostEmojiBox = ({ emojiData, emojiFunc }) => {
 					<img src='/assets/emoji_picker_dropdown_icon.svg' alt='' />
 				</S.DropdownButton>
 				{isEmojiDropDownOpen && (
-					<EmojiDropDown emojiList={usedEmojiList} emojiFunc={emojiFunc} />
+					<EmojiDropDown
+						emojiList={usedEmojiList}
+						emojiFunc={emojiFunc}
+						recipientId={recipientId}
+					/>
 				)}
 				<DropdownClickCancel
 					isOpen={isEmojiDropDownOpen}

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
@@ -18,6 +18,7 @@ const EmojiDropDown = ({ emojiList, emojiFunc, recipientId }) => {
 					{emojiList.map((item) => (
 						<S.EmojiUsedWrapper
 							key={item.emoji}
+							state={localStorage.getItem(item.emoji)}
 							className='font-16-regular'
 							onClick={() =>
 								handleEmojiSelect(item.emoji, recipientId, emojiFunc)
@@ -61,7 +62,11 @@ const MostEmojiBox = ({ emojiData, emojiFunc }) => {
 					favoriteEmoji.map((item) => (
 						<S.EmojiMostUsedWrapper
 							key={item.emoji}
+							state={localStorage.getItem(item.emoji)}
 							className='font-16-regular'
+							onClick={() =>
+								handleEmojiSelect(item.emoji, recipientId, emojiFunc)
+							}
 						>
 							<span>{item.emoji}</span>
 							{item.count}

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
@@ -1,16 +1,6 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router";
 import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel.jsx";
 import * as S from "./MostEmojiBox.style.jsx";
-
-const fetchEmojiData = async (recipientId) => {
-	const { results } = await (
-		await fetch(
-			`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`
-		)
-	).json();
-	return results;
-};
 
 const EmojiDropDown = (emojiList) => {
 	return (
@@ -35,21 +25,10 @@ const EmojiDropDown = (emojiList) => {
 	);
 };
 
-const MostEmojiBox = () => {
+const MostEmojiBox = ({ emojiData }) => {
 	const [isEmojiDropDownOpen, setIsEmojiDropDownOpen] = useState(false);
-	const [emojiData, setEmojiData] = useState([]);
 	const [favoriteEmoji, setFavoriteEmoji] = useState([]);
 	const [usedEmojiList, setUsedEmojiList] = useState([]);
-	const { recipientId } = useParams();
-
-	const handleSetEmojiData = async (recipientId) => {
-		const emojiRaw = await fetchEmojiData(recipientId);
-		setEmojiData(emojiRaw);
-	};
-
-	useEffect(() => {
-		handleSetEmojiData(recipientId);
-	}, [recipientId]);
 
 	useEffect(() => {
 		if (emojiData.length !== 0) {

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
@@ -28,11 +28,13 @@ export const EmojiListContainer = styled.div`
 	top: 4.7rem;
 	row-gap: 1rem;
 	background-color: var(--color-white);
+	z-index: 1;
 	grid-template-columns: ${(prop) =>
 		prop.columns ? prop.columns : "repeat(4, 1fr)"};
 
 	& > span {
 		margin-right: 0.8rem;
+		margin-bottom: 0;
 	}
 
 	@media (max-width: 1024px) {
@@ -42,7 +44,6 @@ export const EmojiListContainer = styled.div`
 
 	@media (max-width: 768px) {
 		padding: 1.6rem;
-		padding-right: 0.8rem;
 	}
 `;
 
@@ -56,6 +57,11 @@ export const EmojiUsedWrapper = styled.div`
 	padding: 0.6rem 1.2rem;
 	gap: 0.2rem;
 	margin-right: 0.8rem;
+	cursor: pointer;
+
+	&:hover {
+		background: rgba(0, 0, 0, 0.65);
+	}
 
 	@media (max-width: 767.5px) {
 		padding: 0.4rem 0.8rem;

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
@@ -5,6 +5,7 @@ export const DropdownFuncBtnContainer = styled.div`
 	display: flex;
 	align-items: center;
 	gap: 0.8rem;
+	z-index: 1;
 `;
 
 export const DropdownButton = styled.button`

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
@@ -47,6 +47,10 @@ export const EmojiListContainer = styled.div`
 	}
 `;
 
+const userStateColors = {
+	increased: "rgba(0, 0, 0, 0.65)",
+};
+
 export const EmojiUsedWrapper = styled.div`
 	display: flex;
 	align-items: center;
@@ -54,13 +58,15 @@ export const EmojiUsedWrapper = styled.div`
 	border-radius: 3.2rem;
 	color: var(--color-white);
 	background: rgba(0, 0, 0, 0.54);
+	background: ${({ state }) => userStateColors[state]};
+
 	padding: 0.6rem 1.2rem;
 	gap: 0.2rem;
 	margin-right: 0.8rem;
 	cursor: pointer;
 
 	&:hover {
-		background: rgba(0, 0, 0, 0.65);
+		background: rgba(0, 0, 0, 0.75);
 	}
 
 	@media (max-width: 767.5px) {
@@ -78,8 +84,15 @@ export const EmojiMostUsedWrapper = styled.div`
 	justify-content: center;
 	border-radius: 3.2rem;
 	background: rgba(0, 0, 0, 0.54);
+	background: ${({ state }) => userStateColors[state]};
 	padding: 0.8rem 1.2rem;
 	gap: 0.4rem;
+	cursor: pointer;
+	z-index: 1;
+
+	&:hover {
+		background: rgba(0, 0, 0, 0.75);
+	}
 
 	@media (max-width: 767.5px) {
 		padding: 0.4rem 0.8rem;

--- a/src/pages/post/components/RollingMessageModal/RollingMessageModal.jsx
+++ b/src/pages/post/components/RollingMessageModal/RollingMessageModal.jsx
@@ -1,27 +1,11 @@
 import * as S from "./RollingMessageModal.style.jsx";
 import { StyleSheetManager } from "styled-components";
 import { formatDate } from "../postCard/formatData.js";
-
-const convertRelationColor = (relation) => {
-	switch (relation) {
-		case "지인":
-			return "orange";
-		case "동료":
-			return "purple";
-		case "가족":
-			return "green";
-		case "친구":
-			return "blue";
-		default:
-			return "error";
-	}
-};
+import Relationship from "../postCard/CardRelationship.jsx";
 
 const RollingMessageModal = ({ rollingMessageData, setIsOpen }) => {
 	const { sender, profileImageURL, relationship, createdAt, content, font } =
 		rollingMessageData;
-
-	const relationColor = convertRelationColor(relationship);
 
 	return (
 		<S.RollingMessageModalBackground>
@@ -35,12 +19,7 @@ const RollingMessageModal = ({ rollingMessageData, setIsOpen }) => {
 							<S.RollingMessageSender className='font-20-regular'>
 								From.<span>{sender}</span>
 							</S.RollingMessageSender>
-							<S.RelationBadge
-								color={relationColor}
-								className='font-14-regular'
-							>
-								{relationship}
-							</S.RelationBadge>
+							<Relationship state={relationship}>{relationship}</Relationship>
 						</section>
 					</section>
 					<p>{formatDate(createdAt)}</p>

--- a/src/pages/post/components/Utils/handleEmojiSelect.js
+++ b/src/pages/post/components/Utils/handleEmojiSelect.js
@@ -1,4 +1,4 @@
-import { toastNotify } from "../../../../utils/callToastNotify";
+import { callToastNotify } from "../../../../utils/callToastNotify";
 
 const handleEmojiSelect = async (emoji, recipientId, emojiFunc) => {
 	try {
@@ -37,7 +37,7 @@ const handleEmojiSelect = async (emoji, recipientId, emojiFunc) => {
 			localStorage.getItem(emoji) === "increased"
 				? "리액션이 성공적으로 추가되었습니다."
 				: "리액션이 성공적으로 제거되었습니다.";
-		toastNotify(notifyMessage);
+		callToastNotify(notifyMessage);
 
 		emojiFunc(recipientId);
 	} finally {

--- a/src/pages/post/components/Utils/handleEmojiSelect.js
+++ b/src/pages/post/components/Utils/handleEmojiSelect.js
@@ -1,0 +1,47 @@
+import { toastNotify } from "../../../../utils/callToastNotify";
+
+const handleEmojiSelect = async (emoji, recipientId, emojiFunc) => {
+	try {
+		if (localStorage.getItem(emoji) !== "increased") {
+			await fetch(
+				`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
+				{
+					method: "POST",
+					headers: {
+						accept: "application/json",
+						"Content-Type": "application/json",
+						"X-CSRFToken":
+							"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
+					},
+					body: JSON.stringify({ emoji: emoji, type: "increase" }),
+				}
+			);
+			localStorage.setItem(emoji, "increased");
+		} else {
+			await fetch(
+				`https://rolling-api.vercel.app/4-2/recipients/${recipientId}/reactions/`,
+				{
+					method: "POST",
+					headers: {
+						accept: "application/json",
+						"Content-Type": "application/json",
+						"X-CSRFToken":
+							"Bk3gqgI4mVP95yjXHakJ56YvHIICSlhOI4lQEztPAT734s9WjGvk04ga24gCLkb6",
+					},
+					body: JSON.stringify({ emoji: emoji, type: "decrease" }),
+				}
+			);
+			localStorage.setItem(emoji, "decreased");
+		}
+		const notifyMessage =
+			localStorage.getItem(emoji) === "increased"
+				? "리액션이 성공적으로 추가되었습니다."
+				: "리액션이 성공적으로 제거되었습니다.";
+		toastNotify(notifyMessage);
+
+		emojiFunc(recipientId);
+	} finally {
+	}
+};
+
+export default handleEmojiSelect;

--- a/src/utils/callToastNotify.js
+++ b/src/utils/callToastNotify.js
@@ -1,6 +1,10 @@
 import { Bounce, toast } from "react-toastify";
 
-const toastNotify = (toastMessage = "default Message") =>
+/**
+ * @param toastMessage - 이 함수가 호출 되었을때, 보여줄 메시지를 넣습니다.
+ * @description - 특정 동작에 무언가 알림이 필요할 때 알려줄 토스트를 호출합니다.
+ */
+const callToastNotify = (toastMessage = "default Message") =>
 	toast.success(toastMessage, {
 		position: "bottom-center",
 		autoClose: 5000,
@@ -13,4 +17,4 @@ const toastNotify = (toastMessage = "default Message") =>
 		transition: Bounce,
 	});
 
-export { toastNotify };
+export { callToastNotify };


### PR DESCRIPTION
## 주요 변경 사항 #44 

### Emoji #42 
 - 이모지에 마우스 호버시 매우 짙은 색, 반응했을 시 약간 짙은색으로 반응 유무를 표현
 - 반응한 이모지 정보를 localStorage에 저장하여 재반응시 해당 이모지의 반응을 취소하도록 함
 - 반응/취소시 toast함수를 호출하여 어떤 동작이 실행되었는지 표시되도록 함.
 - 이모지 추가 버튼 뿐만이 아니라 반응한 이모지를 클릭하여 추가/취소를 실행할 수 있게 함.

### 버그
 - PostCardList의 배경이 relative화 함에 따라 우선순위 문제로 이미지 드롭다운이 숨겨지던 문제 해결
 - 이모지 현황에 이모지 추가/제거 기능이 추가됨에 따라 dropdownCancel과의 우선순위 충돌 문제를 제거하기 위하여 z-index를 2로 조정.
 - 이모지를 등록하려고 할 때, 등록된 이모지를 새로고침해야 확인할 수 있던 문제 해결.

### 리팩토링
 - PostMessageModal의 관계도 배지를 PostCard의 CardRelationship 컴포넌트로 교체.
 - toastNotify.jsx의 jsDoc을 간략하게 추가함.
 - 토스트 호출 함수가 담긴 파일 이름(toastNotify.jsx)과 함수명 (callToastNotify)을 callToastNotify로 통일하여 파일 이름만으로 함수의 이름을 알 수 있게 함.

### 개선점
 - HeaderServiceBox에서 드릴을 뚫지 않더라도 Hook을 이용하여 이모지 새로 고침 및 등록을 해결할 수 있을 것 같은데 아직 방법이 떠오르지 않음.