### PR TITLE
🐛 게시물을 삭제했을때 무한스크롤이 제대로 작동하지 않는 버그 수정

### DIFF
--- a/src/pages/post/components/postCard/PostCardItem.jsx
+++ b/src/pages/post/components/postCard/PostCardItem.jsx
@@ -37,6 +37,14 @@ export function PostCardItem() {
     setCardData([...cardData, ...paperData]);
   }
 
+  async function deleteFetchData() {
+    const jsonData = await getRecipientMessages(
+      `${BASE_URL}/recipients/${recipientId}/messages/?limit=${cardData.length}`
+    );
+
+    const paperData = jsonData.results;
+    setCardData(paperData);
+  }
   useEffect(() => {
     fetchFirstData();
   }, []);
@@ -65,7 +73,9 @@ export function PostCardItem() {
       fetch(deleteUrl, { method: "DELETE" });
 
       setTimeout(function () {
-        fetchFirstData();
+        deleteFetchData();
+        setPage(cardData.length);
+        setAmountDataCount((prev) => prev - 1);
         navigate(`/post/${recipientId}/edit`);
       }, 300);
     }
@@ -85,7 +95,7 @@ export function PostCardItem() {
             <S.CardHeader>
               <S.ProfileImage
                 src={el.profileImageURL}
-                alt="이미지"
+                alt='이미지'
               ></S.ProfileImage>
               <S.CardHeaderContainer>
                 <S.CardHeaderName>


### PR DESCRIPTION
## 변경사항
게시물 삭제후 초기 데이터로 돌아가지 않고 유저가 스크롤한 데이터를 그대로 보여줍니다
게시물이 삭제되었을때 무한스크롤이 제대로 작동하지 않는 버그를 고쳤습니다