### PR TITLE
🐛 메인페이지에서 이모지 목록 보여줄때 한번 추가하고 뺀 이모티콘 개수가 0개로 보이는 버그

### DIFF
--- a/src/pages/list/components/Card/Card.jsx
+++ b/src/pages/list/components/Card/Card.jsx
@@ -66,13 +66,17 @@ const Card = ({ data }) => {
         {data?.topReactions.length > 0 ? (
           <S.BadgeContainer>
             {data?.topReactions.map((reaction) => {
-              return (
-                <S.Badge key={reaction.id}>
-                  <span className="number">
-                    {reaction.emoji} {reaction.count}
-                  </span>
-                </S.Badge>
-              );
+              if (reaction.count > 0) {
+                return (
+                  <S.Badge key={reaction.id}>
+                    <span className="number">
+                      {reaction.emoji} {reaction.count}
+                    </span>
+                  </S.Badge>
+                );
+              } else {
+                return null;
+              }
             })}
           </S.BadgeContainer>
         ) : (


### PR DESCRIPTION
### 주요 변경 사항

- 카드 컴포넌트 렌더링 시, 이모지 개수가 0인 항목은 제외함