### PR TITLE
[Post, Post-to, main] 포켓몬 모달 성능 개선 및 각 페이지마다 세부 스타일 수정 

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -22,19 +22,19 @@ const AppRouter = () => {
       <ThemeProvider>
         <GlobalStyles />
         <Routes>
-          <Route path="/" element={<MainPage />} />
-          <Route path="/list" element={<ListPage />} />
-          <Route path="/post" element={<PostToPage />} />
-          <Route path="/post">
-            <Route path=":recipientId/message" element={<PostMessagePage />} />
-            <Route path=":recipientId" element={<PostPage />}>
-              <Route path="edit" element={<DeleteButton />} />
+          <Route path='/' element={<MainPage />} />
+          <Route path='/list' element={<ListPage />} />
+          <Route path='/post' element={<PostToPage />} />
+          <Route path='/post'>
+            <Route path=':recipientId/message' element={<PostMessagePage />} />
+            <Route path=':recipientId' element={<PostPage />}>
+              <Route path='edit' element={<DeleteButton />} />
             </Route>
           </Route>
         </Routes>
         <ToastContainer
-          className="font-16-regular"
-          position="bottom-center"
+          className='font-16-regular'
+          position='bottom-center'
           autoClose={5000}
           hideProgressBar={true}
           newestOnTop={false}
@@ -43,7 +43,7 @@ const AppRouter = () => {
           pauseOnFocusLoss
           draggable
           pauseOnHover
-          theme="light"
+          theme='light'
         />
       </ThemeProvider>
     </BrowserRouter>

--- a/src/components/navigationBar/NavigationBar.style.jsx
+++ b/src/components/navigationBar/NavigationBar.style.jsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 const NavContainer = styled.nav`
   display: flex;
   justify-content: center;
-  width: 100vw;
   border-bottom: 0.1rem solid #ededed;
   background: ${(props) => props.theme.backgroundColor};
   .nav-container {

--- a/src/pages/list/ListPage.style.jsx
+++ b/src/pages/list/ListPage.style.jsx
@@ -11,6 +11,7 @@ export const Container = styled.div`
     align-items: center;
     overflow-x: hidden;
     padding: 0 2.4rem;
+    border-bottom: 0.1rem solid #ededed;
   }
   .main-container {
     display: flex;

--- a/src/pages/list/components/Card/Card.jsx
+++ b/src/pages/list/components/Card/Card.jsx
@@ -36,30 +36,32 @@ const Card = ({ data }) => {
     >
       <S.ContentContainer>
         <S.InfoContainer>
-          <p className="font-24-bold">To. {data.name}</p>
+          <div className='recipient-name-box'>
+            <p className='font-24-bold'>To. {data.name}</p>
+          </div>
           <S.ProfileContainer>
             {data?.recentMessages?.map((writer) => {
               return (
                 <div key={writer.id}>
                   <img
-                    className="profile-icon"
+                    className='profile-icon'
                     src={writer.profileImageURL}
-                    alt="프로필 이미지"
+                    alt='프로필 이미지'
                   />
                 </div>
               );
             })}
             {data?.messageCount > 3 && (
-              <div className="nums font-12-regular">
+              <div className='nums font-12-regular'>
                 + {data.messageCount - 3}
               </div>
             )}
             {data?.messageCount === 0 && (
-              <div className="nums font-12-regular">+ 0</div>
+              <div className='nums font-12-regular'>+ 0</div>
             )}
           </S.ProfileContainer>
-          <p className="font-16-regular">
-            <span className="font-16-bold">{data.messageCount}</span>명이
+          <p className='font-16-regular'>
+            <span className='font-16-bold'>{data.messageCount}</span>명이
             작성했어요!
           </p>
         </S.InfoContainer>
@@ -69,7 +71,7 @@ const Card = ({ data }) => {
               if (reaction.count > 0) {
                 return (
                   <S.Badge key={reaction.id}>
-                    <span className="number">
+                    <span className='number'>
                       {reaction.emoji} {reaction.count}
                     </span>
                   </S.Badge>
@@ -82,7 +84,7 @@ const Card = ({ data }) => {
         ) : (
           <S.EmptyBadgeContainer />
         )}
-        {svgLink && <img className="svg" src={svgLink} alt="svg" />}
+        {svgLink && <img className='svg' src={svgLink} alt='svg' />}
       </S.ContentContainer>
     </S.Container>
   );

--- a/src/pages/list/components/Card/Card.style.jsx
+++ b/src/pages/list/components/Card/Card.style.jsx
@@ -56,6 +56,13 @@ export const InfoContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
+
+  .recipient-name-box {
+    width: 22.7rem;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 `;
 
 export const ProfileContainer = styled.div`

--- a/src/pages/post-to/components/profile/PokemonModalLoading.style.jsx
+++ b/src/pages/post-to/components/profile/PokemonModalLoading.style.jsx
@@ -42,7 +42,7 @@ export const Wrapper = styled.div`
 
   p {
     font-size: 5rem;
-    margin-top: 2rem;
+
     text-align: center;
   }
 `;

--- a/src/pages/post-to/components/profile/PokemonProfileModal.jsx
+++ b/src/pages/post-to/components/profile/PokemonProfileModal.jsx
@@ -2,37 +2,35 @@ import * as S from "./PokemonProfileModal.style";
 import { useEffect, useState } from "react";
 import PokemonModalLoading from "./PokemonModalLoading";
 const PokemonProfileModal = ({ setIsShowPokemonModal, setProfileInput }) => {
-  const [pokemonData, setPokemonData] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const allPokemonData = [];
+  const [pokemonDataArr, setPokemonDataArr] = useState([]);
+
   const getData = async () => {
-    for (let i = 1; i <= 151; i++) {
-      const pokemonData = await (
-        await fetch(`https://pokeapi.co/api/v2/pokemon-species/${i}`)
-      ).json();
+    const speciesData = await (
+      await fetch(`https://pokeapi.co/api/v2/pokemon-species/?limit=151`)
+    ).json();
 
-      const detailData = await (
-        await fetch(`https://pokeapi.co/api/v2/pokemon/${i}/`)
-      ).json();
+    const speciesList = speciesData.results;
 
-      const koreanName = pokemonData.names.filter(
-        (item) => item.language.name === "ko"
-      )[0].name;
+    for (let poke in speciesList) {
+      if (Number(poke) === 30) {
+        setIsLoading((prev) => !prev);
+      }
+      const speciesUrl = await (await fetch(speciesList[poke].url)).json();
 
-      const pokemonImageUrl = detailData.sprites.front_default;
-
-      const index = detailData.game_indices.filter(
-        (item) => item.version.name === "gold"
-      )[0]["game_index"];
-
-      allPokemonData.push({
-        index: index,
-        name: koreanName,
-        imageUrl: pokemonImageUrl,
-      });
+      setPokemonDataArr((prev) => [
+        ...prev,
+        {
+          index: Number(poke) + 1,
+          name: speciesUrl.names.filter(
+            (item) => item.language.name === "ko"
+          )[0].name,
+          imageUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${
+            Number(poke) + 1
+          }.png`,
+        },
+      ]);
     }
-    setPokemonData(allPokemonData);
-    setIsLoading((prev) => !prev);
   };
 
   useEffect(() => {
@@ -57,7 +55,7 @@ const PokemonProfileModal = ({ setIsShowPokemonModal, setProfileInput }) => {
             </div>
 
             <div className='pokemon-image-container'>
-              {pokemonData.map(({ index, name, imageUrl }) => {
+              {pokemonDataArr.map(({ index, name, imageUrl }) => {
                 return (
                   <div
                     className='pokemon-detail-box'

--- a/src/pages/post-to/components/profile/PokemonProfileModal.jsx
+++ b/src/pages/post-to/components/profile/PokemonProfileModal.jsx
@@ -1,42 +1,24 @@
 import * as S from "./PokemonProfileModal.style";
 import { useEffect, useState } from "react";
 import PokemonModalLoading from "./PokemonModalLoading";
-const PokemonProfileModal = ({ setIsShowPokemonModal, setProfileInput }) => {
-  const [isLoading, setIsLoading] = useState(true);
-  const [pokemonDataArr, setPokemonDataArr] = useState([]);
-
-  const getData = async () => {
-    const speciesData = await (
-      await fetch(`https://pokeapi.co/api/v2/pokemon-species/?limit=151`)
-    ).json();
-
-    const speciesList = speciesData.results;
-
-    for (let poke in speciesList) {
-      if (Number(poke) === 30) {
-        setIsLoading((prev) => !prev);
-      }
-      const speciesUrl = await (await fetch(speciesList[poke].url)).json();
-
-      setPokemonDataArr((prev) => [
-        ...prev,
-        {
-          index: Number(poke) + 1,
-          name: speciesUrl.names.filter(
-            (item) => item.language.name === "ko"
-          )[0].name,
-          imageUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${
-            Number(poke) + 1
-          }.png`,
-        },
-      ]);
-    }
-  };
-
+const PokemonProfileModal = ({
+  setIsShowPokemonModal,
+  setProfileInput,
+  isLoading,
+  pokemonDataArr,
+  setIsLoading,
+}) => {
+  const sortData = pokemonDataArr.sort((a, b) => a.index - b.index);
   useEffect(() => {
-    getData();
-  }, []);
+    const loadingTimer = setTimeout(() => {
+      setIsLoading((prev) => !prev);
+    }, 3000);
 
+    return () => {
+      clearTimeout(loadingTimer);
+      setIsLoading((prev) => !prev);
+    };
+  }, []);
   return (
     <S.Wrapper>
       <S.Box>
@@ -55,7 +37,7 @@ const PokemonProfileModal = ({ setIsShowPokemonModal, setProfileInput }) => {
             </div>
 
             <div className='pokemon-image-container'>
-              {pokemonDataArr.map(({ index, name, imageUrl }) => {
+              {sortData.map(({ index, name, imageUrl }) => {
                 return (
                   <div
                     className='pokemon-detail-box'

--- a/src/pages/post-to/components/profile/PokemonProfileModal.jsx
+++ b/src/pages/post-to/components/profile/PokemonProfileModal.jsx
@@ -29,7 +29,7 @@ const PokemonProfileModal = ({
                 src='/assets/post-to/poke_ball_icon.png'
                 alt='pokeball-icon'
               />
-              <p className='modal-title'>원하는 포켓몬을 선택하세요!!</p>
+              <p className='modal-title'>원하는 포켓몬을 선택하세요!!!</p>
               <img
                 src='/assets/post-to/poke_ball_icon.png'
                 alt='pokeball-icon'

--- a/src/pages/post-to/components/profile/PokemonProfileModal.style.jsx
+++ b/src/pages/post-to/components/profile/PokemonProfileModal.style.jsx
@@ -12,7 +12,7 @@ export const Wrapper = styled.div`
 
 export const Box = styled.div`
   width: 70rem;
-  height: 80rem;
+  height: 75rem;
   background: #fff;
   position: absolute;
   top: 50%;

--- a/src/pages/post-to/components/profile/PokemonProfileModal.style.jsx
+++ b/src/pages/post-to/components/profile/PokemonProfileModal.style.jsx
@@ -13,7 +13,7 @@ export const Wrapper = styled.div`
 export const Box = styled.div`
   width: 70rem;
   height: 75rem;
-  background: #fff;
+  background-color: ${(props) => props.theme.backgroundColor};
   position: absolute;
   top: 50%;
   left: 50%;

--- a/src/pages/post-to/components/profile/Profile.jsx
+++ b/src/pages/post-to/components/profile/Profile.jsx
@@ -10,7 +10,8 @@ const Profile = () => {
   const { profileInput, setProfileInput } = useContext(ProfileContext);
   const [imageList, setImageList] = useState();
   const [isShowPokemonModal, setIsShowPokemonModal] = useState(false);
-
+  const [isLoading, setIsLoading] = useState(true);
+  const [pokemonDataArr, setPokemonDataArr] = useState([]);
   const getProfileImageList = async () => {
     fetch("https://rolling-api.vercel.app/profile-images/")
       .then((res) => res.json())
@@ -20,7 +21,32 @@ const Profile = () => {
       });
   };
 
+  const getData = async () => {
+    const speciesData = await (
+      await fetch(`https://pokeapi.co/api/v2/pokemon-species/?limit=151`)
+    ).json();
+
+    const speciesList = speciesData.results;
+
+    speciesList.forEach(async (data, index) => {
+      const dataList = await (await fetch(data.url)).json();
+
+      setPokemonDataArr((prev) => [
+        ...prev,
+        {
+          index: Number(index) + 1,
+          name: dataList.names.filter((item) => item.language.name === "ko")[0]
+            .name,
+          imageUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${
+            Number(index) + 1
+          }.png`,
+        },
+      ]);
+    });
+  };
+
   useEffect(() => {
+    getData();
     getProfileImageList();
   }, []);
 
@@ -30,27 +56,31 @@ const Profile = () => {
         <PokemonProfileModal
           setIsShowPokemonModal={setIsShowPokemonModal}
           setProfileInput={setProfileInput}
+          getData={getData}
+          isLoading={isLoading}
+          pokemonDataArr={pokemonDataArr}
+          setIsLoading={setIsLoading}
         />
       )}
-      <img className="selected-profile" src={profileInput} alt="프로필" />
-      <div className="select-profile">
-        <p className="text font-16-regular">프로필 이미지를 선택해주세요!</p>
+      <img className='selected-profile' src={profileInput} alt='프로필' />
+      <div className='select-profile'>
+        <p className='text font-16-regular'>프로필 이미지를 선택해주세요!</p>
         <button
-          className="pokemon-profile-button"
+          className='pokemon-profile-button'
           onClick={() => {
             setIsShowPokemonModal((prev) => !prev);
           }}
         >
           포켓몬 이미지 선택하기
         </button>
-        <div className="profile-container">
+        <div className='profile-container'>
           {imageList?.slice(1).map((imgUrl, idx) => {
             return (
               <img
                 key={idx}
-                className="profile"
+                className='profile'
                 src={imgUrl}
-                alt="프로필 이미지"
+                alt='프로필 이미지'
                 onClick={() => setProfileInput(imgUrl)}
               />
             );

--- a/src/pages/post-to/components/profile/Profile.jsx
+++ b/src/pages/post-to/components/profile/Profile.jsx
@@ -10,8 +10,7 @@ const Profile = () => {
   const { profileInput, setProfileInput } = useContext(ProfileContext);
   const [imageList, setImageList] = useState();
   const [isShowPokemonModal, setIsShowPokemonModal] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [pokemonDataArr, setPokemonDataArr] = useState([]);
+
   const getProfileImageList = async () => {
     fetch("https://rolling-api.vercel.app/profile-images/")
       .then((res) => res.json())
@@ -21,32 +20,7 @@ const Profile = () => {
       });
   };
 
-  const getData = async () => {
-    const speciesData = await (
-      await fetch(`https://pokeapi.co/api/v2/pokemon-species/?limit=151`)
-    ).json();
-
-    const speciesList = speciesData.results;
-
-    speciesList.forEach(async (data, index) => {
-      const dataList = await (await fetch(data.url)).json();
-
-      setPokemonDataArr((prev) => [
-        ...prev,
-        {
-          index: Number(index) + 1,
-          name: dataList.names.filter((item) => item.language.name === "ko")[0]
-            .name,
-          imageUrl: `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${
-            Number(index) + 1
-          }.png`,
-        },
-      ]);
-    });
-  };
-
   useEffect(() => {
-    getData();
     getProfileImageList();
   }, []);
 
@@ -56,10 +30,6 @@ const Profile = () => {
         <PokemonProfileModal
           setIsShowPokemonModal={setIsShowPokemonModal}
           setProfileInput={setProfileInput}
-          getData={getData}
-          isLoading={isLoading}
-          pokemonDataArr={pokemonDataArr}
-          setIsLoading={setIsLoading}
         />
       )}
       <img className='selected-profile' src={profileInput} alt='프로필' />

--- a/src/pages/post-to/index.jsx
+++ b/src/pages/post-to/index.jsx
@@ -90,37 +90,37 @@ const PostToPage = () => {
 
   return (
     <>
-      <NavigationBar show="none" />
+      <NavigationBar show='none' />
       <PostToStyle>
-        <div className="container">
+        <div className='container'>
           <div>
-            <p className="recipient-title font-24-bold">To.</p>
-            <form className="recipient-input-form">
+            <p className='recipient-title font-24-bold'>To.</p>
+            <form className='recipient-input-form'>
               <input
                 className={`recipient-input font-16-regular ${
                   inputError ? "error" : ""
                 }`}
-                placeholder="받는 사람 이름을 입력해 주세요."
+                placeholder='받는 사람 이름을 입력해 주세요.'
                 value={recipientName}
                 onChange={handleInputChange}
                 onBlur={handleInputError}
               />
               {inputError && (
-                <div className="error-message-container">
-                  <p className="error-message font-12-regular">
+                <div className='error-message-container'>
+                  <p className='error-message font-12-regular'>
                     값을 입력해주세요.
                   </p>
                 </div>
               )}
             </form>
           </div>
-          <div className="background-container">
-            <p className="text font-24-bold">배경화면을 선택해 주세요</p>
-            <p className="sub-text font-16-regular">
+          <div className='background-container'>
+            <p className='text font-24-bold'>배경화면을 선택해 주세요</p>
+            <p className='sub-text font-16-regular'>
               컬러를 선택하거나, 이미지를 선택할 수 있습니다.
             </p>
           </div>
-          <div className="buttons">
+          <div className='buttons'>
             <button
               className={`font-16-regular ${type === "color" && "select"}`}
               onClick={() => {
@@ -138,7 +138,7 @@ const PostToPage = () => {
               이미지
             </button>
           </div>
-          <div className="card-container">
+          <div className='card-container'>
             <CardList
               type={type}
               cardColorChecks={cardColorChecks}

--- a/src/pages/post/components/DropdownClickCancel/DropdownClickCancel.jsx
+++ b/src/pages/post/components/DropdownClickCancel/DropdownClickCancel.jsx
@@ -21,7 +21,7 @@ const CancelButtonAction = styled.div`
 const DropdownClickCancel = ({ setIsOpen }) => {
   return (
     <>
-      <CancelButtonAction type="button" onClick={() => setIsOpen(false)} />
+      <CancelButtonAction type='button' onClick={() => setIsOpen(false)} />
     </>
   );
 };

--- a/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.style.jsx
+++ b/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.style.jsx
@@ -21,7 +21,7 @@ export const Button = styled.button`
     }
   }
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: #ededed;
   }
 `;
 

--- a/src/pages/post/components/HeaderFeatureBox/HeaderFeatureBox.jsx
+++ b/src/pages/post/components/HeaderFeatureBox/HeaderFeatureBox.jsx
@@ -6,10 +6,12 @@ import * as S from "./HeaderFeatureBox.style";
  */
 const HeaderFeatureBox = ({ recipientData }) => {
   return (
-    <S.Container>
-      <MessageRecipient recipientData={recipientData} />
-      <HeaderToolBar recipientData={recipientData} />
-    </S.Container>
+    <S.ContainerWrapper>
+      <S.Container>
+        <MessageRecipient recipientData={recipientData} />
+        <HeaderToolBar recipientData={recipientData} />
+      </S.Container>
+    </S.ContainerWrapper>
   );
 };
 

--- a/src/pages/post/components/HeaderFeatureBox/HeaderFeatureBox.style.jsx
+++ b/src/pages/post/components/HeaderFeatureBox/HeaderFeatureBox.style.jsx
@@ -1,8 +1,6 @@
 import styled from "styled-components";
 
-
 export const ContainerWrapper = styled.div`
-  width: 100vw;
   background-color: ${(props) => props.theme.backgroundColor};
 `;
 

--- a/src/pages/post/components/HeaderShareButton/HeaderShareButton.jsx
+++ b/src/pages/post/components/HeaderShareButton/HeaderShareButton.jsx
@@ -14,15 +14,15 @@ const HeaderShareButton = () => {
   return (
     <>
       <S.Button
-        type="button"
+        type='button'
         onClick={(e) => {
           handleModalClick();
         }}
       >
         <img
-          src="/assets/post/header_share_button_icon.svg"
-          className="share-button-image"
-          alt="share-button"
+          src='/assets/post/header_share_button_icon.svg'
+          className='share-button-image'
+          alt='share-button'
         />
       </S.Button>
 

--- a/src/pages/post/components/HeaderShareButton/HeaderShareButton.style.jsx
+++ b/src/pages/post/components/HeaderShareButton/HeaderShareButton.style.jsx
@@ -12,7 +12,7 @@ export const Button = styled.button`
   cursor: pointer;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: #ededed;
   }
 
   @media (max-width: 767.5px) {

--- a/src/pages/post/components/ShareDropdownModal/ShareDropdownModal.jsx
+++ b/src/pages/post/components/ShareDropdownModal/ShareDropdownModal.jsx
@@ -1,12 +1,13 @@
 import * as S from "./ShareDropdownModal.style";
 import { callToastNotify } from "../../../../utils/callToastNotify";
 import { shareKakao } from "../../../../utils/shareKakao";
+import DropdownClickCancel from "../DropdownClickCancel/DropdownClickCancel";
 const ShareDropDownModal = ({ setIsShowModal }) => {
   return (
     <S.Box>
       <S.Button
-        type="button"
-        className="font-16-regular"
+        type='button'
+        className='font-16-regular'
         onClick={() => {
           setIsShowModal((prev) => !prev);
           shareKakao(
@@ -19,8 +20,8 @@ const ShareDropDownModal = ({ setIsShowModal }) => {
         카카오톡 공유
       </S.Button>
       <S.Button
-        type="button"
-        className="font-16-regular"
+        type='button'
+        className='font-16-regular'
         onClick={() => {
           setIsShowModal((prev) => !prev);
           callToastNotify("URL이 복사 되었습니다.");

--- a/src/pages/post/components/WriterImageBox/WriterImageBox.jsx
+++ b/src/pages/post/components/WriterImageBox/WriterImageBox.jsx
@@ -6,7 +6,7 @@ const WriterImageBox = ({ data }) => {
       {data.recentMessages?.map(({ profileImageURL, id }) => {
         return (
           <S.Box profileImageUrl={profileImageURL} key={id}>
-            <img src={profileImageURL} className='profile-icon' />
+            <img src={profileImageURL} className='profile-icon' alt='profile' />
           </S.Box>
         );
       })}

--- a/src/pages/post/components/WriterImageBox/WriterImageBox.jsx
+++ b/src/pages/post/components/WriterImageBox/WriterImageBox.jsx
@@ -4,12 +4,16 @@ const WriterImageBox = ({ data }) => {
   return (
     <S.Container>
       {data.recentMessages?.map(({ profileImageURL, id }) => {
-        return <S.Box $profileImageUrl={profileImageURL} key={id}></S.Box>;
+        return (
+          <S.Box profileImageUrl={profileImageURL} key={id}>
+            <img src={profileImageURL} className='profile-icon' />
+          </S.Box>
+        );
       })}
 
       {data?.messageCount > 3 && (
         <S.NumberBox>
-          <p className="font-12-regular">+{data?.messageCount - 3}</p>
+          <p className='font-12-regular'>+{data?.messageCount - 3}</p>
         </S.NumberBox>
       )}
     </S.Container>

--- a/src/pages/post/components/WriterImageBox/WriterImageBox.style.jsx
+++ b/src/pages/post/components/WriterImageBox/WriterImageBox.style.jsx
@@ -5,7 +5,8 @@ export const Container = styled.div`
 `;
 
 export const Box = styled.div`
-  width: 2.8rem;
+  ${
+    "" /* width: 2.8rem;
   height: 2.8rem;
   border-radius: 500rem;
   overflow: hidden;
@@ -14,7 +15,21 @@ export const Box = styled.div`
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;
-  margin-left: -1rem;
+  margin-left: -1rem; */
+  }
+
+  .profile-icon {
+    width: 2.8rem;
+    height: 2.8rem;
+    margin-right: -1rem;
+    display: flex;
+    padding: 0.2rem;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    border-radius: 3rem;
+    background: #fff;
+  }
 `;
 
 export const NumberBox = styled.div`
@@ -26,7 +41,7 @@ export const NumberBox = styled.div`
   border-radius: 500rem;
   background-color: var(--color-white);
   border: 0.2rem solid #e3e3e3;
-  margin-left: -1rem;
+  margin-left: 0.1rem;
 
   p {
     font-weight: 500;

--- a/src/pages/post/components/WriterImageBox/WriterImageBox.style.jsx
+++ b/src/pages/post/components/WriterImageBox/WriterImageBox.style.jsx
@@ -5,19 +5,6 @@ export const Container = styled.div`
 `;
 
 export const Box = styled.div`
-  ${
-    "" /* width: 2.8rem;
-  height: 2.8rem;
-  border-radius: 500rem;
-  overflow: hidden;
-  border: 0.2rem solid #fff;
-  background-image: url(${({ $profileImageUrl }) => $profileImageUrl});
-  background-position: center;
-  background-size: cover;
-  background-repeat: no-repeat;
-  margin-left: -1rem; */
-  }
-
   .profile-icon {
     width: 2.8rem;
     height: 2.8rem;


### PR DESCRIPTION
#### 💡 꼭 체크해주세요

- [x] 제목 : [최상위 폴더명] 말머리 표시
- [x] review 지정
- [x] label 1개 이상 지정
- [x] milestone 지정
- [x] issue 연결

## 주요 변경 사항
Post 페이지 lighthouse 검사를 했는데 웹 접근성 부분에서 100점이 나오고 다른 부분에서도 딱히 고칠만한 부분이 보이지 않아 대신 추가 기능으로 만들었던 포켓몬 모달에서 API 데이터를 불러오는 속도를 향상시켰습니다

### 포켓몬 모달
- 기존에 for 반복문에서 limit으로 데이터를 한번에 불러와 forEach를 통해 데이터를 불러옵니다
-프로필 페이지에서 데이터를 불러오고 바로 모달에 렌더링시 순서가 바뀌는것을 방지하기 위해 로딩화면 표시와 함께 데이터를 index순으로 정렬시켜 데이터들을 렌더링합니다
- 로딩상태, 에러처리를 추가했습니다

### 디자인 수정
 - NavBar 크기가 잘못 설정되어 가로 스크롤이 나타나는 부분을 고쳤습니다
 - 포켓몬 모달의 세부 디자인을 수정했습니다
 - List 페이지에서 카드 컴포넌트에 받은사람 이름이 카드 컴포넌트보다 더 길 경우 줄바꿈이 되는 현상을 고쳤습니다
 - 다크모드에서 post페이지 버튼들이 hover 상태인경우 검은색에서 약한 회색으로 변경했습니다
 - Post페이지에서 헤더부분 프로필 이미지에서 포켓몬 프로필을 선택할경우 디자인이 이상해지는 현상을 고쳤습니다



## 기타 논의사항 / 해결해야 할 것

- 
