### PR TITLE
[post-to] 🐛 포켓몬 모달이 닫히지 않는 버그 수정

### DIFF
--- a/src/pages/post-to/components/profile/PokemonProfileModal.jsx
+++ b/src/pages/post-to/components/profile/PokemonProfileModal.jsx
@@ -52,7 +52,7 @@ const PokemonProfileModal = ({ setIsShowPokemonModal, setProfileInput }) => {
 
   return (
     <>
-      <S.Wrapper onClick={() => setIsShowPokemonModal((prev) => !prev)}>
+      <S.Wrapper onClick={() => setIsShowPokemonModal(false)}>
         <S.Box>
           {isLoading && <PokemonModalLoading />}
           {!isLoading && error && <p>{error}</p>}
@@ -79,7 +79,7 @@ const PokemonProfileModal = ({ setIsShowPokemonModal, setProfileInput }) => {
                         className='pokemon-detail-box'
                         onClick={() => {
                           setProfileInput(imageUrl);
-                          setIsShowPokemonModal((prev) => !prev);
+                          setIsShowPokemonModal(false);
                         }}
                         key={index}
                       >


### PR DESCRIPTION
#### 💡 꼭 체크해주세요

- [ ] 제목 : [최상위 폴더명] 말머리 표시
- [ ] review 지정
- [ ] label 1개 이상 지정
- [ ] milestone 지정
- [ ] issue 연결

## 주요 변경 사항

- 포켓몬 프로필 선택시 모달이 닫히지 않는 버그를 수정했습니다.


-