### PR TITLE
[list] tablet, mobile 스크롤 해결 및 전체 데이터에 대해 정렬

### DIFF
--- a/src/pages/list/ListPage.style.jsx
+++ b/src/pages/list/ListPage.style.jsx
@@ -66,32 +66,3 @@ export const ButtonContainer = styled.div`
     }
   }
 `;
-
-export const EmptyCardList = styled.div`
-  width: 27.5rem;
-  height: 26rem;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  padding: 2.4rem;
-
-  border-radius: 1.6rem;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  background: var(--color-surface);
-  color: var(--color-black);
-  box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
-
-  .svg-container {
-    display: flex;
-    justify-content: flex-end;
-    .svg {
-      width: 10rem;
-      height: 10rem;
-    }
-  }
-
-  @media screen and (min-width: 375px) and (max-width: 1024px) {
-    margin: 0 2.4rem;
-  }
-`;

--- a/src/pages/list/components/Card/Card.jsx
+++ b/src/pages/list/components/Card/Card.jsx
@@ -29,8 +29,6 @@ const Card = ({ data }) => {
     }
   }, [data.backgroundColor]);
 
-  console.log(data?.topReactions);
-
   return (
     <S.Container
       color={bgColor.length > 0 ? bgColor : data.backgroundImageURL}

--- a/src/pages/list/components/Card/Card.jsx
+++ b/src/pages/list/components/Card/Card.jsx
@@ -29,6 +29,8 @@ const Card = ({ data }) => {
     }
   }, [data.backgroundColor]);
 
+  console.log(data?.topReactions);
+
   return (
     <S.Container
       color={bgColor.length > 0 ? bgColor : data.backgroundImageURL}
@@ -36,42 +38,42 @@ const Card = ({ data }) => {
     >
       <S.ContentContainer>
         <S.InfoContainer>
-          <div className='recipient-name-box'>
-            <p className='font-24-bold'>To. {data.name}</p>
+          <div className="recipient-name-box">
+            <p className="font-24-bold">To. {data.name}</p>
           </div>
           <S.ProfileContainer>
             {data?.recentMessages?.map((writer) => {
               return (
                 <div key={writer.id}>
                   <img
-                    className='profile-icon'
+                    className="profile-icon"
                     src={writer.profileImageURL}
-                    alt='프로필 이미지'
+                    alt="프로필 이미지"
                   />
                 </div>
               );
             })}
             {data?.messageCount > 3 && (
-              <div className='nums font-12-regular'>
+              <div className="nums font-12-regular">
                 + {data.messageCount - 3}
               </div>
             )}
             {data?.messageCount === 0 && (
-              <div className='nums font-12-regular'>+ 0</div>
+              <div className="nums font-12-regular">+ 0</div>
             )}
           </S.ProfileContainer>
-          <p className='font-16-regular'>
-            <span className='font-16-bold'>{data.messageCount}</span>명이
+          <p className="font-16-regular">
+            <span className="font-16-bold">{data.messageCount}</span>명이
             작성했어요!
           </p>
         </S.InfoContainer>
-        {data?.topReactions.length > 0 ? (
+        {data?.reactionCount > 0 ? (
           <S.BadgeContainer>
             {data?.topReactions.map((reaction) => {
               if (reaction.count > 0) {
                 return (
                   <S.Badge key={reaction.id}>
-                    <span className='number'>
+                    <span className="number">
                       {reaction.emoji} {reaction.count}
                     </span>
                   </S.Badge>
@@ -84,7 +86,7 @@ const Card = ({ data }) => {
         ) : (
           <S.EmptyBadgeContainer />
         )}
-        {svgLink && <img className='svg' src={svgLink} alt='svg' />}
+        {svgLink && <img className="svg" src={svgLink} alt="svg" />}
       </S.ContentContainer>
     </S.Container>
   );

--- a/src/pages/list/components/CardList/CardList.jsx
+++ b/src/pages/list/components/CardList/CardList.jsx
@@ -7,54 +7,13 @@ import Card from "../Card/Card";
 /**
  *
  * @description CardList 컴포넌트는 Card 컴포넌트를 리스트로 보여주는 컴포넌트입니다.
- * @param {data} object 롤링페이퍼 데이터
+ * @param {string} type popular | recent
  */
-const CardList = ({ data }) => {
+const CardList = ({ type }) => {
   const [isLeftOn, setIsLeftOn] = useState(false);
   const [isRightOn, setIsRightOn] = useState(false);
   const [displayData, setDisplayData] = useState();
   const [currHeadIdx, setCurrHeadIdx] = useState(0);
-
-  // 보여줄 데이터 세팅
-  useEffect(() => {
-    setDisplayData(data.slice(0, 4));
-  }, []);
-
-  // 카드 목록 개수가 4개 이상일 때만 화살표 버튼을 보여줍니다.
-  useEffect(() => {
-    if (data.length > 4) {
-      setIsRightOn(true);
-    }
-  }, []);
-
-  // 화살표 버튼 클릭 시 보여줄 데이터 변경
-  const changeRange = (clickedType) => {
-    if (clickedType === "right") {
-      setDisplayData(data.slice(currHeadIdx + 1, currHeadIdx + 5));
-      setCurrHeadIdx(currHeadIdx + 1);
-    } else if (clickedType === "left") {
-      setCurrHeadIdx(currHeadIdx - 1);
-      setDisplayData(data.slice(currHeadIdx - 1, currHeadIdx + 3));
-    }
-  };
-
-  // 화살표 버튼 노출 여부
-  useEffect(() => {
-    if (data.length < 4) {
-      setIsRightOn(false);
-    } else {
-      if (currHeadIdx === 0) {
-        setIsLeftOn(false);
-      } else {
-        setIsLeftOn(true);
-      }
-      if (currHeadIdx === data.length - 4) {
-        setIsRightOn(false);
-      } else {
-        setIsRightOn(true);
-      }
-    }
-  }, [currHeadIdx, data.length]);
 
   //  반응형 렌더링
   const [isDesktop, setIsDesktop] = useState(window.innerWidth > 1250);
@@ -71,6 +30,76 @@ const CardList = ({ data }) => {
     };
   }, []);
 
+  // 모든 데이터 가져와서 정렬
+  const sortPopularData = (data) => {
+    return [...data].sort((a, b) => b.messageCount - a.messageCount);
+  };
+
+  const sortRecentData = (data) => {
+    return [...data].sort((a, b) => {
+      return new Date(b.createdAt) - new Date(a.createdAt);
+    });
+  };
+
+  const getAll = async (amount) => {
+    const response = await fetch(
+      `https://rolling-api.vercel.app/4-2/recipients/?limit=${amount}`
+    );
+    const data = await response.json();
+    if (type === "popular") {
+      setDisplayData(sortPopularData(data.results));
+    } else if (type === "recent") {
+      setDisplayData(sortRecentData(data.results));
+    }
+  };
+
+  // 처음 렌더링 시 데이터 개수만 먼저 가져오기
+  const getRecipientList = async () => {
+    fetch("https://rolling-api.vercel.app/4-2/recipients/")
+      .then((res) => res.json())
+      .then((data) => {
+        getAll(data.count);
+      });
+  };
+
+  useEffect(() => {
+    getRecipientList();
+  }, []);
+
+  // 카드 목록 개수가 4개 이상일 때만 화살표 버튼을 보여줍니다.
+  useEffect(() => {
+    if (displayData?.length > 4) {
+      setIsRightOn(true);
+    }
+  }, [displayData?.length]);
+
+  // 화살표 버튼 클릭 시 보여줄 데이터 변경
+  const changeRange = (clickedType) => {
+    if (clickedType === "right") {
+      setCurrHeadIdx(currHeadIdx + 1);
+    } else if (clickedType === "left") {
+      setCurrHeadIdx(currHeadIdx - 1);
+    }
+  };
+
+  // 화살표 버튼 노출 여부
+  useEffect(() => {
+    if (displayData?.length < 4) {
+      setIsRightOn(false);
+    } else {
+      if (currHeadIdx === 0) {
+        setIsLeftOn(false);
+      } else {
+        setIsLeftOn(true);
+      }
+      if (currHeadIdx === displayData?.length - 4) {
+        setIsRightOn(false);
+      } else {
+        setIsRightOn(true);
+      }
+    }
+  }, [currHeadIdx, displayData?.length]);
+
   if (isDesktop) {
     return (
       <S.DesktopContainer isLeftOn={isLeftOn}>
@@ -79,7 +108,7 @@ const CardList = ({ data }) => {
             <ArrowBtn type="left" onClick={() => changeRange("left")} />
           )}
           <div className="paper-list">
-            {displayData?.map((data) => {
+            {displayData?.slice(currHeadIdx, currHeadIdx + 4).map((data) => {
               return <Card key={data.id} data={data} />;
             })}
           </div>
@@ -99,6 +128,7 @@ const CardList = ({ data }) => {
             })}
           </div>
         </div>
+        <div></div>
       </S.TabletContainer>
     );
   }

--- a/src/pages/list/components/CardList/CardList.jsx
+++ b/src/pages/list/components/CardList/CardList.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import * as S from "./CardList.style";
 import ArrowBtn from "../ArrowBtn/ArrowBtn";
 import Card from "../Card/Card";
+import EmptyCard from "../EmptyCard/EmptyCard";
 
 /**
  *
@@ -107,11 +108,15 @@ const CardList = ({ type }) => {
           {isLeftOn && (
             <ArrowBtn type="left" onClick={() => changeRange("left")} />
           )}
-          <div className="paper-list">
-            {displayData?.slice(currHeadIdx, currHeadIdx + 4).map((data) => {
-              return <Card key={data.id} data={data} />;
-            })}
-          </div>
+          {displayData?.length > 0 ? (
+            <div className="paper-list">
+              {displayData?.slice(currHeadIdx, currHeadIdx + 4).map((data) => {
+                return <Card key={data.id} data={data} />;
+              })}
+            </div>
+          ) : (
+            <EmptyCard />
+          )}
           {isRightOn && (
             <ArrowBtn type="right" onClick={() => changeRange("right")} />
           )}
@@ -122,11 +127,15 @@ const CardList = ({ type }) => {
     return (
       <S.TabletContainer>
         <div className="list-with-btn">
-          <div className="paper-list">
-            {displayData?.map((data) => {
-              return <Card key={data.id} data={data} />;
-            })}
-          </div>
+          {!displayData?.length > 0 ? (
+            <div className="paper-list">
+              {displayData?.map((data) => {
+                return <Card key={data.id} data={data} />;
+              })}
+            </div>
+          ) : (
+            <EmptyCard />
+          )}
         </div>
         <div></div>
       </S.TabletContainer>

--- a/src/pages/list/components/CardList/CardList.jsx
+++ b/src/pages/list/components/CardList/CardList.jsx
@@ -127,7 +127,7 @@ const CardList = ({ type }) => {
     return (
       <S.TabletContainer>
         <div className="list-with-btn">
-          {!displayData?.length > 0 ? (
+          {displayData?.length > 0 ? (
             <div className="paper-list">
               {displayData?.map((data) => {
                 return <Card key={data.id} data={data} />;

--- a/src/pages/list/components/EmptyCard/EmptyCard.jsx
+++ b/src/pages/list/components/EmptyCard/EmptyCard.jsx
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+
+const EmptyCard = () => {
+  return (
+    <EmptyCardList>
+      <h3 className="font-24-bold">
+        아직 작성된
+        <br />
+        롤링페이퍼가 없어요
+      </h3>
+      <div className="svg-container">
+        <img className="svg" src="/assets/link/empty.svg" alt="empty" />
+      </div>
+    </EmptyCardList>
+  );
+};
+
+export default EmptyCard;
+
+const EmptyCardList = styled.div`
+  width: 27.5rem;
+  height: 26rem;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 2.4rem;
+
+  border-radius: 1.6rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background: var(--color-surface);
+  color: var(--color-black);
+  box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.08);
+
+  .svg-container {
+    display: flex;
+    justify-content: flex-end;
+    .svg {
+      width: 10rem;
+      height: 10rem;
+    }
+  }
+`;

--- a/src/pages/list/index.jsx
+++ b/src/pages/list/index.jsx
@@ -10,36 +10,6 @@ import CardList from "./components/CardList/CardList";
  * @description ListPage 컴포넌트는 인기 롤링페이퍼와 최근에 만든 롤링페이퍼를 보여주는 페이지입니다!
  */
 const ListPage = () => {
-  const [popularData, setPopularData] = useState();
-  const [recentData, setRecentData] = useState();
-
-  useEffect(() => {
-    getRecipientList();
-  }, []);
-
-  const getRecipientList = async () => {
-    fetch("https://rolling-api.vercel.app/4-2/recipients/")
-      .then((res) => res.json())
-      .then((data) => {
-        sortPopularData(data.results);
-        sortRecentData(data.results);
-      });
-  };
-
-  const sortPopularData = (data) => {
-    const sortedData = [...data].sort(
-      (a, b) => b.messageCount - a.messageCount
-    );
-    setPopularData(sortedData);
-  };
-
-  const sortRecentData = (data) => {
-    const sortedData = [...data].sort((a, b) => {
-      return new Date(b.createdAt) - new Date(a.createdAt);
-    });
-    setRecentData(sortedData);
-  };
-
   return (
     <S.Container>
       <div className="gnb-container">
@@ -48,9 +18,9 @@ const ListPage = () => {
       <div className="main-container">
         <div className="list-container">
           <h1 className="font-24-bold title">인기 롤링 페이퍼 🔥</h1>
-          {popularData ? (
-            <CardList data={popularData} />
-          ) : (
+          {/* {popularData ? ( */}
+          <CardList type="popular" />
+          {/* ) : (
             <S.EmptyCardList>
               <h3 className="font-24-bold">
                 아직 작성된
@@ -61,11 +31,12 @@ const ListPage = () => {
                 <img className="svg" src="/assets/link/empty.svg" alt="empty" />
               </div>
             </S.EmptyCardList>
-          )}
+          )} */}
         </div>
         <div className="list-container">
           <h1 className="font-24-bold title">최근에 만든 롤링 페이퍼 ⭐️</h1>
-          {recentData && <CardList data={recentData} />}
+          {/* {recentData && <CardList type="recent" />} */}
+          <CardList type="recent" />
         </div>
       </div>
       <S.ButtonContainer>

--- a/src/pages/list/index.jsx
+++ b/src/pages/list/index.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 import * as S from "./ListPage.style";
@@ -18,24 +17,10 @@ const ListPage = () => {
       <div className="main-container">
         <div className="list-container">
           <h1 className="font-24-bold title">인기 롤링 페이퍼 🔥</h1>
-          {/* {popularData ? ( */}
           <CardList type="popular" />
-          {/* ) : (
-            <S.EmptyCardList>
-              <h3 className="font-24-bold">
-                아직 작성된
-                <br />
-                롤링페이퍼가 없어요
-              </h3>
-              <div className="svg-container">
-                <img className="svg" src="/assets/link/empty.svg" alt="empty" />
-              </div>
-            </S.EmptyCardList>
-          )} */}
         </div>
         <div className="list-container">
           <h1 className="font-24-bold title">최근에 만든 롤링 페이퍼 ⭐️</h1>
-          {/* {recentData && <CardList type="recent" />} */}
           <CardList type="recent" />
         </div>
       </div>


### PR DESCRIPTION
#### 💡 꼭 체크해주세요

- [x] 제목 : [최상위 폴더명] 말머리 표시
- [x] review 지정
- [x] label 1개 이상 지정
- [x] milestone 지정
- [x] issue 연결

## 주요 변경 사항

- tablet, mobile 사이즈에서도 스크롤하면 추가 데이터를 계속해서 볼 수 있게 수정
- 이전에는 offset으로 인해 데이터 일부에 대해 정렬 후 보여줬는데, 이제 전체 데이터를 불러와서 정렬 후 보여주는 방식으로 변경
- 작성된 롤링 페이퍼가 하나도 없을 때 처리

## 스크린샷

<img width="500" alt="image" src="https://github.com/innerstella/itsBasic/assets/77491430/106aa859-382d-42eb-a645-3e5f96bf2875">
<img width="500" alt="image" src="https://github.com/innerstella/itsBasic/assets/77491430/1a30d8e2-3076-4f70-ba28-677b67e5943f">



## 기타 논의사항 / 해결해야 할 것

- 무한 스크롤로 로딩을 하고 싶었는데, 정확히 정렬하려면 일단 전체 데이터를 불러와야 해서 조금 비효율적인 방법으로 구현했습니다. 애초에 백엔드에서 정렬을 시켜줬다면 더 좋았을 것 같다는 생각이...?
