### PR TITLE
[Post]💄 Post 페이지 헤더부분 깨지는 현상 해결, 헤더부분 드롭다운 아이콘 다크모드에 맞춰 색상 변경 적용

### DIFF
--- a/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
+++ b/src/pages/post/components/HeaderAddEmojiButton/HeaderAddEmojiButton.jsx
@@ -17,17 +17,17 @@ function HeaderAddEmojiButton({ emojiFunc }) {
   return (
     <S.EmojiToggleBtnContainer>
       <S.Button
-        type="button"
-        className="font-16-regular"
+        type='button'
+        className='font-16-regular'
         onClick={() => setIsEmojiOpen(!isEmojiOpen)}
       >
-        <img src="/assets/post/icons/add-24.svg" alt="" />
+        <img src='/assets/post/icons/add-24.svg' alt='' />
         추가
       </S.Button>
       <S.EmojiPickerPositioner>
         {isEmojiOpen && (
           <EmojiPicker
-            emojiStyle="twitter"
+            emojiStyle='twitter'
             onEmojiClick={(sel) =>
               handleEmojiSelect(sel.emoji, recipientId, emojiFunc)
             }

--- a/src/pages/post/components/HeaderToolBar/HeaderToolBar.style.jsx
+++ b/src/pages/post/components/HeaderToolBar/HeaderToolBar.style.jsx
@@ -7,5 +7,6 @@ export const Container = styled.div`
   @media (max-width: 767.5px) {
     width: 100%;
     padding: 0.8rem 2rem;
+    border-top: 0.1rem solid #ededed;
   }
 `;

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.jsx
@@ -16,7 +16,7 @@ const EmojiDropDown = ({ emojiList, emojiFunc, recipientId }) => {
     <>
       {emojiList.length === 0 ? (
         <S.EmojiListContainer columns={"1fr"}>
-          <span className="font-16-regular">
+          <span className='font-16-regular'>
             이모지를 선택하여 이 글에 반응해보세요!
           </span>
         </S.EmojiListContainer>
@@ -26,7 +26,7 @@ const EmojiDropDown = ({ emojiList, emojiFunc, recipientId }) => {
             <S.EmojiUsedWrapper
               key={item.emoji}
               $state={localStorage.getItem(item.emoji)}
-              className="font-16-regular"
+              className='font-16-regular'
               onClick={() =>
                 handleEmojiSelect(item.emoji, recipientId, emojiFunc)
               }
@@ -69,7 +69,7 @@ const MostEmojiBox = ({ emojiData, emojiFunc }) => {
     <>
       <S.DropdownFuncBtnContainer>
         {favoriteEmoji.length === 0 ? (
-          <S.EmojiMostUsedWrapper className="font-16-regular">
+          <S.EmojiMostUsedWrapper className='font-16-regular'>
             아직 글에 반응이 없어요.
           </S.EmojiMostUsedWrapper>
         ) : (
@@ -77,7 +77,7 @@ const MostEmojiBox = ({ emojiData, emojiFunc }) => {
             <S.EmojiMostUsedWrapper
               key={item.emoji}
               $state={localStorage.getItem(item.emoji)}
-              className="font-16-regular"
+              className='font-16-regular'
               onClick={() =>
                 handleEmojiSelect(item.emoji, recipientId, emojiFunc)
               }
@@ -88,10 +88,28 @@ const MostEmojiBox = ({ emojiData, emojiFunc }) => {
           ))
         )}
         <S.DropdownButton
-          type="button"
+          type='button'
           onClick={() => setIsEmojiDropDownOpen(!isEmojiDropDownOpen)}
         >
-          <img src="/assets/post/emoji_picker_dropdown_icon.svg" alt="" />
+          <svg
+            width='24'
+            height='24'
+            viewBox='0 0 24 24'
+            fill='none'
+            xmlns='http://www.w3.org/2000/svg'
+          >
+            <g id='ic / arrow_down'>
+              <path
+                id='Polygon 1'
+                d='M6.00024 8.76923L12.0002 15.2308L18.0002 8.76924'
+                stroke='#101010'
+                stroke-width='1.5'
+                stroke-linecap='round'
+                stroke-linejoin='round'
+                className='drop-down-icon'
+              />
+            </g>
+          </svg>
         </S.DropdownButton>
         {isEmojiDropDownOpen && (
           <EmojiDropDown

--- a/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
+++ b/src/pages/post/components/MostEmojiBox/MostEmojiBox.style.jsx
@@ -13,7 +13,9 @@ export const DropdownButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-
+  .drop-down-icon {
+    stroke: ${(props) => props.theme.textColor};
+  }
   & img {
     border-radius: 50%;
     &:hover {

--- a/src/pages/post/components/PostPageMain/PostPageMain.jsx
+++ b/src/pages/post/components/PostPageMain/PostPageMain.jsx
@@ -24,7 +24,7 @@ const PostPageMain = ({
 
       {currentURL.includes("edit") || (
         <ST.Box>
-          <ST.StyledLink to="edit">삭제하기</ST.StyledLink>
+          <ST.StyledLink to='edit'>삭제하기</ST.StyledLink>
         </ST.Box>
       )}
 

--- a/src/pages/post/index.jsx
+++ b/src/pages/post/index.jsx
@@ -29,7 +29,9 @@ const PostPage = () => {
     <S.Layout>
       <S.OverScrollBox />
       <S.UpperHeaderWrapper>
-        <NavigationBar show={"none"} />
+        <div className='main-nav-box'>
+          <NavigationBar show={"none"} />
+        </div>
         <HeaderFeatureBox recipientData={recipientData} />
       </S.UpperHeaderWrapper>
       <PostPageMain

--- a/src/pages/post/index.style.jsx
+++ b/src/pages/post/index.style.jsx
@@ -3,9 +3,15 @@ import NavigationBar from "../../components/navigationBar/NavigationBar";
 
 export const UpperHeaderWrapper = styled.div`
   position: relative;
-  width: 100vw;
+
   background-color: var(--color-white);
   z-index: 1;
+
+  .main-nav-box {
+    @media (max-width: 767.5px) {
+      display: none;
+    }
+  }
 `;
 
 export const UpperHeaderBar = styled(NavigationBar)`
@@ -23,8 +29,6 @@ export const OverScrollBox = styled.div`
 `;
 
 export const Layout = styled.div`
-  position: relative;
-
   &::after {
     content: "";
     position: absolute;

--- a/src/theme/ThemeToggle.jsx
+++ b/src/theme/ThemeToggle.jsx
@@ -17,13 +17,8 @@ function ThemeToggle({ toggle, mode }) {
 export default ThemeToggle;
 
 const ToggleWrapper = styled.button`
-  /* position: fixed;
-  z-index: 999;
-  bottom: 4%;
-  right: 3%; */
-
   background: ${(props) => props.theme.backgroundColor};
-  /* border: ${(props) => props.theme.borderColor}; */
+
   font-size: 20px;
 
   display: flex;


### PR DESCRIPTION
#### 💡 꼭 체크해주세요

- [x] 제목 : [최상위 폴더명] 말머리 표시
- [x] review 지정
- [x] label 1개 이상 지정
- [x] milestone 지정
- [x] issue 연결

## 주요 변경 사항

- 게시물 데이터가 두줄 이상일때 헤더가 깨지는 현상을 고쳤습니다
- 다크모드 적용시 드롭다운 아이콘의 색상이 변경됩니다

## 스크린샷

<img width="228" alt="스크린샷 2024-03-11 182501" src="https://github.com/innerstella/itsBasic/assets/90647684/fe4daf1a-ebea-403e-add4-108fabb60082">
<img width="236" alt="스크린샷 2024-03-11 182504" src="https://github.com/innerstella/itsBasic/assets/90647684/7c2aa845-fbf4-47ce-8ef9-ed55dc91c180">


## 기타 논의사항 / 해결해야 할 것

- 
