### PR TITLE
[main]💄 메인페이지 두번째 이미지 모바일에서 비율 안맞는 문제 해결

### DIFF
--- a/src/pages/main/MainPage.style.jsx
+++ b/src/pages/main/MainPage.style.jsx
@@ -146,7 +146,6 @@ const MainPageStyle = styled.div`
     .emoji-image {
       width: 100%;
       max-width: 47rem;
-      min-height: 26rem;
       margin: 0 auto 5.1rem auto;
       padding: 0 2.98rem;
     }

--- a/src/pages/main/index.jsx
+++ b/src/pages/main/index.jsx
@@ -12,47 +12,47 @@ const MainPage = () => {
     <>
       <NavigationBar show={"show"} />
       <MainPageStyle>
-        <div className="box-container">
-          <div className="text-container">
-            <h1 className="point font-14-bold">Point. 01</h1>
-            <h2 className="text font-24-bold">
+        <div className='box-container'>
+          <div className='text-container'>
+            <h1 className='point font-14-bold'>Point. 01</h1>
+            <h2 className='text font-24-bold'>
               누구나 손쉽게, 온라인 <span>롤링 페이지를 만들 수 있어요</span>
             </h2>
-            <h3 className="sub-text font-18-regular">
+            <h3 className='sub-text font-18-regular'>
               로그인 없이 자유롭게 만들어요.
             </h3>
           </div>
-          <div className="card-container">
+          <div className='card-container'>
             <img
-              src="/assets/main/service_card_image.webp"
-              className="card-image"
-              alt="카드 예시 이미지"
+              src='/assets/main/service_card_image.webp'
+              className='card-image'
+              alt='카드 예시 이미지'
             />
           </div>
         </div>
-        <div className="box-container box-container-bottom">
+        <div className='box-container box-container-bottom'>
           <img
-            className="emoji-image"
-            src="/assets/main/service_image_emoji.webp"
-            alt="이모지 예시 이미지"
+            className='emoji-image'
+            src='/assets/main/service_image_emoji.webp'
+            alt='이모지 예시 이미지'
           ></img>
-          <div className="text-container">
-            <h1 className="point font-14-bold">Point. 02</h1>
-            <h2 className="text font-24-bold">
+          <div className='text-container'>
+            <h1 className='point font-14-bold'>Point. 02</h1>
+            <h2 className='text font-24-bold'>
               서로에게 이모지로 감정을 <span>표현해보세요</span>
             </h2>
-            <h3 className="sub-text font-18-regular">
+            <h3 className='sub-text font-18-regular'>
               롤링 페이퍼에 이모지를 추가할 수 있어요.
             </h3>
           </div>
         </div>
-        <Link to="/list">
+        <Link to='/list'>
           <motion.button
-            className="btn"
+            className='btn'
             whileHover={{ scale: 1.1 }}
             whileTap={{ scale: 0.9 }}
           >
-            <span className="font-18-bold">구경해보기</span>
+            <span className='font-18-bold'>구경해보기</span>
           </motion.button>
         </Link>
       </MainPageStyle>


### PR DESCRIPTION
#### 💡 꼭 체크해주세요

- [x] 제목 : [최상위 폴더명] 말머리 표시
- [x] review 지정
- [x] label 1개 이상 지정
- [x] milestone 지정
- [ ] issue 연결

## 주요 변경 사항

- 미디어 쿼리 모바일 사이즈에서  min-height때문에 비율이 안맞게 설정되서 그냥 지웠습니다 min-height 설정해놓으면 이미지 비율만 깨지고 나머지는 그대로라 지우는게 나을듯합니다

## 스크린샷

<img width="362" alt="스크린샷 2024-03-11 222419" src="https://github.com/innerstella/itsBasic/assets/90647684/c1eb382e-d181-4e5a-adbf-f5d9c4f6048a">

변경전
<img width="355" alt="스크린샷 2024-03-11 222451" src="https://github.com/innerstella/itsBasic/assets/90647684/c6b10730-9ac9-4a45-9d2a-09c9a6dd51e0">

변경후




## 기타 논의사항 / 해결해야 할 것

- 
